### PR TITLE
Excuse Menu Update

### DIFF
--- a/src/commands/moderation/admin-routes/admin-excuses.js
+++ b/src/commands/moderation/admin-routes/admin-excuses.js
@@ -38,7 +38,7 @@ module.exports = async (interaction, subcommand) => {
             return interaction.editReply({
                 embeds: [new MessageEmbed({
                     color: 'GREEN',
-                    title: '✅ Successfully cleared ' + deletedCount + ' excuse(s) for ' + day,
+                    title: '✅ Successfully cleared ' + deletedCount + ' excuse' + (deletedCount != 1 ? 's' : '') + ' for ' + day,
                     description: '> Additionally, if excuses for this day were paused, they have been resumed.'
                 })]
             });

--- a/src/commands/moderation/admin-routes/admin-excuses.js
+++ b/src/commands/moderation/admin-routes/admin-excuses.js
@@ -15,7 +15,14 @@ module.exports = async (interaction, subcommand) => {
     switch (subcommand) {
         case 'clear': {
             await interaction.deferReply();
+            const server = ExcuseHandler.Servers.cache.get(interaction.guild.id);
             const { deletedCount } = await ExcuseHandler.clearDayAndDeleteThread(interaction, day);
+
+            // re-render the menu
+            ExcuseHandler.fetchMenuMessage(interaction, server).then(menuMessage => {
+                if (!menuMessage) return;
+                ExcuseHandler.renderMenu(menuMessage, server);
+            });
 
             // if nothing was deleted, inform and do not resume
             if (deletedCount === 0) return interaction.editReply({
@@ -27,7 +34,7 @@ module.exports = async (interaction, subcommand) => {
             });
 
             // resume and inform success
-            ExcuseHandler.resume(interaction, day);
+            ExcuseHandler.resume(interaction.guild.id, day);
             return interaction.editReply({
                 embeds: [new MessageEmbed({
                     color: 'GREEN',
@@ -38,7 +45,14 @@ module.exports = async (interaction, subcommand) => {
         } // end clear
 
         case 'pause': {
+            const server = ExcuseHandler.Servers.cache.get(interaction.guild.id);
             const successfullyPaused = ExcuseHandler.pause(interaction.guild.id, day);
+
+            // re-render the menu
+            ExcuseHandler.fetchMenuMessage(interaction, server).then(menuMessage => {
+                if (!menuMessage) return;
+                ExcuseHandler.renderMenu(menuMessage, server);
+            });
             
             // paused successfully
             if (successfullyPaused) interaction.reply({
@@ -61,8 +75,15 @@ module.exports = async (interaction, subcommand) => {
         }
 
         case 'unpause': {
+            const server = ExcuseHandler.Servers.cache.get(interaction.guild.id);
             const successfullyResumed = ExcuseHandler.resume(interaction.guild.id, day);
             
+            // re-render the menu
+            ExcuseHandler.fetchMenuMessage(interaction, server).then(menuMessage => {
+                if (!menuMessage) return;
+                ExcuseHandler.renderMenu(menuMessage, server);
+            });
+
             // resumed successfully
             if (successfullyResumed) interaction.reply({
                 embeds: [new MessageEmbed({

--- a/src/commands/moderation/spawn.js
+++ b/src/commands/moderation/spawn.js
@@ -105,6 +105,7 @@ module.exports = {
                 }
 
                 // finally, spawn the menu and provide a loading screen
+                const server = ExcuseHandler.Servers.cache.get(interaction.guild.id);
                 const menuMessage = interaction.channel.send({
                     embeds: [new MessageEmbed()
                         .setColor('BLURPLE')
@@ -120,17 +121,11 @@ module.exports = {
                         )
                     ],
                     components: [
-                        new MessageActionRow({
-                            components: ExcuseHandler.days.map(day => new MessageButton({
-                                customId: 'EXCUSEBUTTON:' + day.toUpperCase(),
-                                style: 'PRIMARY',
-                                label: day,
-                            })),
-                        }),
+                        new MessageActionRow({ components: ExcuseHandler.generateDayButtons(server) }),
                         new MessageActionRow({
                             components: [new MessageButton({
                                 customId: 'EXCUSEBUTTON_VIEW',
-                                style: 'SECONDARY',
+                                style: 'PRIMARY',
                                 label: 'View the status of your excuses',
                                 emoji: '📝'
                             })],
@@ -140,7 +135,6 @@ module.exports = {
                 
                 // defer and pull server from the cache
                 await interaction.deferReply({ ephemeral: true });
-                const server = ExcuseHandler.Servers.cache.get(interaction.guild.id);
                 
                 // save excuse menu channel/message id and processing channel id and notify
                 ExcuseHandler.setMenuMessage(server, interaction.channel.id, (await menuMessage).id);

--- a/src/commands/moderation/spawn.js
+++ b/src/commands/moderation/spawn.js
@@ -105,7 +105,7 @@ module.exports = {
                 }
 
                 // finally, spawn the menu and provide a loading screen
-                interaction.channel.send({
+                const menuMessage = interaction.channel.send({
                     embeds: [new MessageEmbed()
                         .setColor('BLURPLE')
                         .setTitle('📝 Excuse Form Requests')
@@ -113,6 +113,9 @@ module.exports = {
                             'Need to excuse yourself from a session? Running late or a little behind; need to leave early, perhaps?'
                             + '\n**No worries! We\'ve got you covered!**'
                             + '\n\nExcuse forms are readily available for any needs you may have. If you don\'t feel comfortable sharing the reason, that\'s perfectly fine! Please just let us know and we\'ll accomodate!'
+                            + '\n\n💫 **Please keep in mind**'
+                            + '\nEach excuse form is checked against the attendance for that given day. Sometimes this takes a while, we appreciate your patience 💚'
+                            + '\n\n⏰**All excuses are due UP TO 4 hours after session end, after which submissions will be locked for review.**'
                             + '\n\n💡 **To get started, select the day you wish to fill out a form for. You will then be prompted for what kind of excuse you would like to submit, along with extra details.**'
                         )
                     ],
@@ -139,7 +142,8 @@ module.exports = {
                 await interaction.deferReply({ ephemeral: true });
                 const server = ExcuseHandler.Servers.cache.get(interaction.guild.id);
                 
-                // save excuse processing channel id and notify
+                // save excuse menu channel/message id and processing channel id and notify
+                ExcuseHandler.setMenuMessage(server, interaction.channel.id, (await menuMessage).id);
                 ExcuseHandler.setProcessingChannel(server, processingChannel.id);
                 await server.save();
                 return interaction.editReply({

--- a/src/database/schemas/server.js
+++ b/src/database/schemas/server.js
@@ -21,6 +21,8 @@ const { Schema } = require("mongoose");
  *          pendingToMessageId: Map<string, string>
  *          messageIdToPending: Map<string, string>
  *      },
+ *      excusesMenuChannelId: string,
+ *      excusesMenuMessageId: string,
  *      excusesChannelId: string,
  *      excusesThreads: Map<string, string>,
  *      excusesPaused: Map<string, string>,
@@ -100,6 +102,14 @@ const serverSchema = new Schema({
             of: String,
             default: new Map(),
         }
+    },
+    excusesMenuChannelId: {
+        type: String,
+        default: null,
+    },
+    excusesMenuMessageId: {
+        type: String,
+        default: null,
     },
     excusesChannelId: {
         type: String,


### PR DESCRIPTION
Updated the excuse form submission menu from static to a dynamic menu that updates based on which days are paused/unpaused.

It also displays and tracks the date in which the day was paused for review.

Additionally, added two new fields for the Server schema:
excuseMenuChannelId : where the dynamic menu is located (1 at a time)
excuseMenuMessageId : the message that holds the dynamic menu (1 at a time)